### PR TITLE
Run tinymce outside of angular

### DIFF
--- a/tinymce-angular-component/src/editor/editor.component.ts
+++ b/tinymce-angular-component/src/editor/editor.component.ts
@@ -125,7 +125,9 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
       this.element.style.visibility = '';
     }
 
-    getTinymce().init(finalInit);
+    this.ngZone.runOutsideAngular(() => {
+      getTinymce().init(finalInit);
+    });
   }
 
   private initEditor(editor: any) {


### PR DESCRIPTION
Handlers are bound to inside of the Angular zone, causing every mouse move to trigger a change detection cycle. The PR binds to event handlers outside of the Angular zone, code already exists which emits events in the Angular zone, so no additional work was needed.