### PR TITLE
fix(EditorComponent): wrap initialise call in setTimeout

### DIFF
--- a/tinymce-angular-component/src/editor/editor.component.ts
+++ b/tinymce-angular-component/src/editor/editor.component.ts
@@ -91,7 +91,9 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
         typeof this.inline !== 'undefined' ? (typeof this.inline === 'boolean' ? this.inline : true) : this.init && this.init.inline;
       this.createElement();
       if (getTinymce() !== null) {
-        this.initialise();
+        setTimeout(() => {
+          this.initialise();
+        });
       } else if (this.element && this.element.ownerDocument) {
         const doc = this.element.ownerDocument;
         const channel = this.cloudChannel || 'stable';


### PR DESCRIPTION
When an `<editor>` element is loaded twice dynamically e.g. using an `*ngIf` statement or inside a dialog (that is closed and opened) again, the EditorComponent fails to initialise properly, causing the editor to appear as frozen (editor pane is not clickable or editable).

This PR fixes the initialisation in the `ngAfterViewInit` lifecycle hook so that the editor can properly be initialised multiple times.

This PR should also fix #9.