### PR TITLE
Make editor always invoke touched function on blur. Fixes #54

### DIFF
--- a/tinymce-angular-component/src/editor/editor.component.ts
+++ b/tinymce-angular-component/src/editor/editor.component.ts
@@ -153,7 +153,7 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
     if (typeof this.initialValue === 'string') {
       this.ngZone.run(() => editor.setContent(this.initialValue));
     }
-    editor.once('blur', () => this.ngZone.run(() => this.onTouchedCallback()));
+    editor.on('blur', () => this.ngZone.run(() => this.onTouchedCallback()));
     editor.on(
       'setcontent',
       ({ content, format }: any) => format === 'html' && content && this.ngZone.run(() => this.onChangeCallback(content))


### PR DESCRIPTION
This will fix the issue where the editor does not invoke the reactive forms `touched` function on all blurs, as specified in the Angular docs.

I couldn't find any tests or other things to update. Let me know if needed.