### PR TITLE
Make editor always invoke touched callback on blur. Fixes #54

### DIFF
--- a/tinymce-angular-component/src/editor/editor.component.ts
+++ b/tinymce-angular-component/src/editor/editor.component.ts
@@ -153,7 +153,7 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
     if (typeof this.initialValue === 'string') {
       this.ngZone.run(() => editor.setContent(this.initialValue));
     }
-    editor.once('blur', () => this.ngZone.run(() => this.onTouchedCallback()));
+    editor.on('blur', () => this.ngZone.run(() => this.onTouchedCallback()));
     editor.on(
       'setcontent',
       ({ content, format }: any) => format === 'html' && content && this.ngZone.run(() => this.onChangeCallback(content))


### PR DESCRIPTION
This PR makes the editor invoke the ControlValueAccessor `onTouched` callback on all blurs...not just the first one. This will make the editor work according to the Angular specs:

https://angular.io/api/forms/ControlValueAccessor#registerOnTouched
> When implementing registerOnTouched in your own value accessor, save the given function so your class calls it when the control should be considered blurred or "touched".