### PR TITLE
fix: formControl reset does not clear contents

### DIFF
--- a/tinymce-angular-component/src/editor/editor.component.ts
+++ b/tinymce-angular-component/src/editor/editor.component.ts
@@ -62,6 +62,7 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
 
   writeValue(value: string | null): void {
     this.initialValue = value || this.initialValue;
+    value = value || '';
 
     if (this.editor && this.editor.initialized && typeof value === 'string') {
       this.editor.setContent(value);


### PR DESCRIPTION
https://github.com/angular/angular/blob/7.2.x/packages/forms/src/model.ts#L987

Assuming the editor control is a child of FormGroup, FormGroup.reset() internally 
calls the reset function of `FormControl` with default parameter as `null`.
`value` becomes null and `setContent` is never called. The workaround is to
set value to an empty string to get into the `setContent` if branch.

Example of the bug : https://stackblitz.com/edit/angular-eazrrv
Expected: The editor should be reset and empty
Actual: The editor preserves the previous text