### PR TITLE
change editor property to public

### DIFF
--- a/tinymce-angular-component/src/editor/editor.component.ts
+++ b/tinymce-angular-component/src/editor/editor.component.ts
@@ -24,7 +24,7 @@ const EDITOR_COMPONENT_VALUE_ACCESSOR = {
 export class EditorComponent extends Events implements AfterViewInit, ControlValueAccessor, OnDestroy {
   private elementRef: ElementRef;
   private element: Element | undefined = undefined;
-  private editor: any;
+  public editor: any;
 
   ngZone: NgZone;
 


### PR DESCRIPTION
I use ```@ViewChildren('editor') editors: QueryList<EditorComponent>;``` and need access to the editor property. Currently getting error ```Property 'editor' is private and only accessible within class 'EditorComponent'.```

** resubmitted PR with email as requested by CLA bot