### PR TITLE
Make EventEmitters run inside NgZone

### DIFF
--- a/tinymce-angular-component/src/main/ts/utils/Utils.ts
+++ b/tinymce-angular-component/src/main/ts/utils/Utils.ts
@@ -17,7 +17,7 @@ const bindHandlers = (ctx: EditorComponent, editor: any, initEvent: Event): void
       if (eventName === 'onInit') {
         ctx.ngZone.run(() => eventEmitter.emit({ event: initEvent, editor }));
       } else {
-        editor.on(eventName.substring(2), ctx.ngZone.run(() => (event: any) => eventEmitter.emit({ event, editor })));
+        editor.on(eventName.substring(2), (event) => ctx.ngZone.run(() => eventEmitter.emit({ event, editor })));
       }
     }
   });

--- a/tinymce-angular-component/src/main/ts/utils/Utils.ts
+++ b/tinymce-angular-component/src/main/ts/utils/Utils.ts
@@ -17,7 +17,7 @@ const bindHandlers = (ctx: EditorComponent, editor: any, initEvent: Event): void
       if (eventName === 'onInit') {
         ctx.ngZone.run(() => eventEmitter.emit({ event: initEvent, editor }));
       } else {
-        editor.on(eventName.substring(2), (event) => ctx.ngZone.run(() => eventEmitter.emit({ event, editor })));
+        editor.on(eventName.substring(2), (event: any) => ctx.ngZone.run(() => eventEmitter.emit({ event, editor })));
       }
     }
   });


### PR DESCRIPTION
This fixes https://github.com/tinymce/tinymce-angular/issues/27 (and https://github.com/tinymce/tinymce-angular/issues/79, I think)

The way that the Utils.ts is written (before this pull request), the EventEmitters on the EditorComponent emit their events outside the NgZone, causing unpredictable UI issues because of the interaction between NgZone and Angular change detection.

There is a workaround described in https://github.com/tinymce/tinymce-angular/issues/27, which is to wrap your handler as shown below. This works, but it's highly unexpected, and it's tedious to wrap every handler for every TinyMCE event.

`ngZone.run(() => /* handler */)`

This pull request fixes the problem by changing the event handler in Utils.ts to always run inside the NgZone.