### PR TITLE
Add forceInit$ observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ The editor accepts the following inputs:
 * `toolbar`: Shorthand for setting what toolbar items you want to show, `<editor toolbar="foo bar"></editor>` is the same as setting `{toolbar: 'foo bar'}` in the init.
 * `apiKey`: Api key for TinyMCE cloud, more info below.
 * `cloudChannel`: Cloud channel for TinyMCE Cloud, more info below.
+* `forceInit$`: Observable that remove and init editor.
+```html
+<editor [forceInit$]="forceInit$"></editor>
+```
+```tsx
+this.forceInit$ = new Subject();
+this.forceInit$.next();
+```
 
 None of the configuration inputs are **required** for the editor to work - other than if you are using TinyMCE Cloud you will have to specify the `apiKey` to get rid of the `This domain is not registered...` warning message.
 

--- a/tinymce-angular-component/src/main/ts/editor/editor.component.ts
+++ b/tinymce-angular-component/src/main/ts/editor/editor.component.ts
@@ -160,6 +160,11 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
     });
   }
 
+  public forceInit() {
+    this.removeEditor();
+    this.initialise();
+  }
+
   private initEditor(initEvent: Event, editor: any) {
     if (typeof this.initialValue === 'string') {
       this.ngZone.run(() => editor.setContent(this.initialValue));
@@ -167,11 +172,6 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
     editor.on('blur', () => this.ngZone.run(() => this.onTouchedCallback()));
     editor.on('change keyup undo redo', () => this.ngZone.run(() => this.onChangeCallback(editor.getContent())));
     bindHandlers(this, editor, initEvent);
-  }
-
-  private forceInit() {
-    this.removeEditor();
-    this.initialise();
   }
 
   private removeEditor() {


### PR DESCRIPTION
I added an input variable in `editor.component` to force a reload of tinyEMC. This variable `forceInit$` is an observable that in its subscription calls a new remove method (`removeEditor()`) and `initialise()`.

`removeEditor` has the code that was inside ngOnDestroy method.

Also, I updated docs with the input variable and an example of how to use it.

I created this PR to fix #9. There is another PR to fix the same issue, #50, but is actually stopped and I don't think that add a timeout is a good solution. So my fix is only applied if you want use it manually.

Here is an example of how to use this feature.

In your template
```html
<editor [forceInit$]="forceInit$"></editor>
```

And your controller
```tsx
this.forceInit$ = new Subject();
this.forceInit$.next();
```