### PR TITLE
Listen to input event to support right click paste for ngModel

### DIFF
--- a/tinymce-angular-component/src/main/ts/editor/editor.component.ts
+++ b/tinymce-angular-component/src/main/ts/editor/editor.component.ts
@@ -160,7 +160,7 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
       this.ngZone.run(() => editor.setContent(this.initialValue));
     }
     editor.on('blur', () => this.ngZone.run(() => this.onTouchedCallback()));
-    editor.on('change keyup undo redo', () => this.ngZone.run(() => this.onChangeCallback(editor.getContent())));
+    editor.on('input change keyup undo redo', () => this.ngZone.run(() => this.onChangeCallback(editor.getContent())));
     bindHandlers(this, editor, initEvent);
   }
 }


### PR DESCRIPTION
When right click and paste ngModel doesn't update the text. 