### PR TITLE
Tiny 4688: TinyMCE lazy loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,57 +27,57 @@
 ## 3.0.0 (2019-02-11)
 * Changed default cloudChannel to `'5'`.
 
-# 2.5.0 (2019-01-17)
+## 2.5.0 (2019-01-17)
 * Add EditorComponent to public api.
 
-# 2.4.1 (2019-01-09)
+## 2.4.1 (2019-01-09)
 * Fixed a bug where `FormGroup.reset()` didn't clear the editor content when used in a formgroup. Patch contributed by nishanthkarthik.
 
-# 2.4.0 (2019-01-07)
+## 2.4.0 (2019-01-07)
 * Make editor always invoke touched callback on blur. Patch contributed by joensindholt 
 
-# 2.3.3 (2018-12-14)
+## 2.3.3 (2018-12-14)
 * Improved documentation.
 
-# 2.3.2 (2018-12-03)
+## 2.3.2 (2018-12-03)
 * Change deps to support Angular 7.
 
-# 2.3.1 (2018-10-10)
+## 2.3.1 (2018-10-10)
 * Fixed incorrect documentation in readme.md file.
 
-# 2.3.0 (2018-10-08)
+## 2.3.0 (2018-10-08)
 * Added platform detection to make the package work better with SSR.
 
-# 2.2.0 (2018-09-26)
+## 2.2.0 (2018-09-26)
 * Added support for disabling the editor via the `disabled` attribute.
 
-# 2.1.0 (2018-09-24)
+## 2.1.0 (2018-09-24)
 * Fixed bug where textarea was being added to editor content if id was set.
 * Changed `inline` attribute to accept truthy values, so you can now do this: `<editor inline></editor>` instead of the earlier `<editor [inline]="true"></editor>`.
 
-# 2.0.1 (2018-09-03)
+## 2.0.1 (2018-09-03)
 * Fixed broken links in readme.
 
-# 2.0.0 (2018-05-08)
+## 2.0.0 (2018-05-08)
 * Migrate to Angular and rxjs version 6
 
-# 1.0.9 (2018-05-04)
+## 1.0.9 (2018-05-04)
 * Added `undo` and `redo` events to ngModel onChangeCallback.
 
-# 1.0.8 (2018-04-26)
+## 1.0.8 (2018-04-26)
 * Added null check before removing editor to check that tinymce is actually available.
 
-# 1.0.7 (2018-04-06)
+## 1.0.7 (2018-04-06)
 * Fixed bug with onInit not firing and removed onPreInit shorthand.
 
-# 1.0.6 (2018-04-06)
+## 1.0.6 (2018-04-06)
 * Changed so tinymce.init is run outside of angular with ngzone.
 
-# 1.0.5 (2018-02-15)
+## 1.0.5 (2018-02-15)
 * Fixed bug where is wasn't possible to set inline in the init object, only on the shorthand.
 
-# 1.0.4 (2018-02-14)
+## 1.0.4 (2018-02-14)
 * Fixed bug where the component threw errors because it tried to setContent on an editor that had not been initialized fully.
 
-# 1.0.3 (2018-02-13)
+## 1.0.3 (2018-02-13)
 * Fixed bug where the component threw errors on change when not used together with the forms module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.0 (TBA)
+* Added new `TINYMCE_SCRIPT_SRC` injection token. To be used in a dependency injection provider to specify an external version of TinyMCE to load
+
 ## 3.4.0 (2020-01-31)
 * Added new `outputFormat` property for specifying the format of content emitted to form controls
 

--- a/tinymce-angular-component/src/main/ts/editor/editor.component.ts
+++ b/tinymce-angular-component/src/main/ts/editor/editor.component.ts
@@ -2,11 +2,9 @@ import { isPlatformBrowser } from '@angular/common';
 import { AfterViewInit, Component, ElementRef, forwardRef, Inject, Input, NgZone, OnDestroy, PLATFORM_ID, InjectionToken, Optional } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { getTinymce } from '../TinyMCE';
-import * as ScriptLoader from '../utils/ScriptLoader';
 import { bindHandlers, isTextarea, mergePlugins, uuid, noop, isNullOrUndefined } from '../utils/Utils';
 import { Events } from './Events';
-
-const scriptState = ScriptLoader.create();
+import { ScriptLoader } from '../utils/ScriptLoader';
 
 export const TINYMCE_SCRIPT_SRC = new InjectionToken<string>('TINYMCE_SCRIPT_SRC');
 
@@ -107,7 +105,6 @@ constructor(
         this.initialise();
       } else if (this._element && this._element.ownerDocument) {
         ScriptLoader.load(
-          scriptState,
           this._element.ownerDocument,
           this.getScriptSrc(),
           this.initialise

--- a/tinymce-angular-component/src/main/ts/editor/editor.component.ts
+++ b/tinymce-angular-component/src/main/ts/editor/editor.component.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { AfterViewInit, Component, ElementRef, forwardRef, Inject, Input, NgZone, OnDestroy, PLATFORM_ID } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, forwardRef, Inject, Input, NgZone, OnDestroy, PLATFORM_ID, InjectionToken, Optional } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { getTinymce } from '../TinyMCE';
 import * as ScriptLoader from '../utils/ScriptLoader';
@@ -7,6 +7,8 @@ import { bindHandlers, isTextarea, mergePlugins, uuid, noop, isNullOrUndefined }
 import { Events } from './Events';
 
 const scriptState = ScriptLoader.create();
+
+export const TINYMCE_SCRIPT_SRC = new InjectionToken<string>('TINYMCE_SCRIPT_SRC');
 
 const EDITOR_COMPONENT_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
@@ -59,7 +61,12 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
   private onTouchedCallback = noop;
   private onChangeCallback = noop;
 
-  constructor(elementRef: ElementRef, ngZone: NgZone, @Inject(PLATFORM_ID) private platformId: Object) {
+constructor(
+  elementRef: ElementRef,
+  ngZone: NgZone,
+  @Inject(PLATFORM_ID) private platformId: Object,
+  @Optional() @Inject(TINYMCE_SCRIPT_SRC) private tinymceScriptSrc?: string
+  ) {
     super();
     this._elementRef = elementRef;
     this.ngZone = ngZone;
@@ -99,11 +106,12 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
       if (getTinymce() !== null) {
         this.initialise();
       } else if (this._element && this._element.ownerDocument) {
-        const doc = this._element.ownerDocument;
-        const channel = this.cloudChannel;
-        const apiKey = this.apiKey;
-
-        ScriptLoader.load(scriptState, doc, `https://cdn.tiny.cloud/1/${apiKey}/tinymce/${channel}/tinymce.min.js`, this.initialise);
+        ScriptLoader.load(
+          scriptState,
+          this._element.ownerDocument,
+          this.getScriptSrc(),
+          this.initialise
+        );
       }
     }
   }
@@ -153,6 +161,12 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
     this.ngZone.runOutsideAngular(() => {
       getTinymce().init(finalInit);
     });
+  }
+
+  private getScriptSrc() {
+    return isNullOrUndefined(this.tinymceScriptSrc) ?
+      `https://cdn.tiny.cloud/1/${this.apiKey}/tinymce/${this.cloudChannel}/tinymce.min.js` :
+      this.tinymceScriptSrc;
   }
 
   private initEditor(initEvent: Event, editor: any) {

--- a/tinymce-angular-component/src/main/ts/public_api.ts
+++ b/tinymce-angular-component/src/main/ts/public_api.ts
@@ -1,2 +1,2 @@
 export * from './editor/editor.module';
-export { EditorComponent } from './editor/editor.component';
+export { EditorComponent, TINYMCE_SCRIPT_SRC } from './editor/editor.component';

--- a/tinymce-angular-component/src/main/ts/utils/ScriptLoader.ts
+++ b/tinymce-angular-component/src/main/ts/utils/ScriptLoader.ts
@@ -39,8 +39,8 @@ const CreateScriptLoader = (): ScriptLoader => {
     scriptTag.src = url;
 
     const handler = () => {
-      callback();
       scriptTag.removeEventListener('load', handler);
+      callback();
     };
     scriptTag.addEventListener('load', handler);
     if (doc.head) {

--- a/tinymce-angular-component/src/main/ts/utils/ScriptLoader.ts
+++ b/tinymce-angular-component/src/main/ts/utils/ScriptLoader.ts
@@ -15,19 +15,7 @@ export interface IStateObj {
   scriptLoaded: boolean;
 }
 
-const injectScriptTag = (scriptId: string, doc: Document, url: string, callback: callbackFn) => {
-  const scriptTag = doc.createElement('script');
-  scriptTag.referrerPolicy = 'origin';
-  scriptTag.type = 'application/javascript';
-  scriptTag.id = scriptId;
-  scriptTag.addEventListener('load', callback);
-  scriptTag.src = url;
-  if (doc.head) {
-    doc.head.appendChild(scriptTag);
-  }
-};
-
-const create = (): IStateObj => {
+const createState = (): IStateObj => {
   return {
     listeners: [],
     scriptId: uuid('tiny-script'),
@@ -35,21 +23,53 @@ const create = (): IStateObj => {
   };
 };
 
-const load = (state: IStateObj, doc: Document, url: string, callback: callbackFn) => {
-  if (state.scriptLoaded) {
-    callback();
-  } else {
-    state.listeners.push(callback);
-    if (!doc.getElementById(state.scriptId)) {
-      injectScriptTag(state.scriptId, doc, url, () => {
-        state.listeners.forEach((fn) => fn());
-        state.scriptLoaded = true;
-      });
+interface ScriptLoader {
+  load: (doc: Document, url: string, callback: callbackFn) => void;
+  reinitialize: () => void;
+}
+
+const CreateScriptLoader = (): ScriptLoader => {
+  let state: IStateObj = createState();
+
+  const injectScriptTag = (scriptId: string, doc: Document, url: string, callback: callbackFn) => {
+    const scriptTag = doc.createElement('script');
+    scriptTag.referrerPolicy = 'origin';
+    scriptTag.type = 'application/javascript';
+    scriptTag.id = scriptId;
+    scriptTag.addEventListener('load', callback);
+    scriptTag.src = url;
+    if (doc.head) {
+      doc.head.appendChild(scriptTag);
     }
-  }
+  };
+
+  const load = (doc: Document, url: string, callback: callbackFn) => {
+    if (state.scriptLoaded) {
+      callback();
+    } else {
+      state.listeners.push(callback);
+      if (!doc.getElementById(state.scriptId)) {
+        injectScriptTag(state.scriptId, doc, url, () => {
+          state.listeners.forEach((fn) => fn());
+          state.scriptLoaded = true;
+        });
+      }
+    }
+  };
+
+  // Only to be used by tests.
+  const reinitialize = () => {
+    state = createState();
+  };
+
+  return {
+    load,
+    reinitialize
+  };
 };
 
+const ScriptLoader = CreateScriptLoader();
+
 export {
-  create,
-  load
+  ScriptLoader
 };

--- a/tinymce-angular-component/src/main/ts/utils/ScriptLoader.ts
+++ b/tinymce-angular-component/src/main/ts/utils/ScriptLoader.ts
@@ -36,8 +36,13 @@ const CreateScriptLoader = (): ScriptLoader => {
     scriptTag.referrerPolicy = 'origin';
     scriptTag.type = 'application/javascript';
     scriptTag.id = scriptId;
-    scriptTag.addEventListener('load', callback);
     scriptTag.src = url;
+
+    const handler = () => {
+      callback();
+      scriptTag.removeEventListener('load', handler);
+    };
+    scriptTag.addEventListener('load', handler);
     if (doc.head) {
       doc.head.appendChild(scriptTag);
     }

--- a/tinymce-angular-component/src/test/ts/browser/FormControlTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/FormControlTest.ts
@@ -8,8 +8,7 @@ import { Assertions, Chain, Log, Pipeline } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { VersionLoader } from '@tinymce/miniature';
 
-import { EditorComponent } from '../../../main/ts/editor/editor.component';
-import { EditorModule } from '../../../main/ts/editor/editor.module';
+import { EditorComponent, EditorModule } from '../../../main/ts/public_api';
 
 UnitTest.asynctest('FormControlTest', (success, failure) => {
   @Component({

--- a/tinymce-angular-component/src/test/ts/browser/LoadTinyTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/LoadTinyTest.ts
@@ -6,7 +6,7 @@ import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { Chain, Log, Pipeline, Assertions } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Arr, Strings } from '@ephox/katamari';
+import { Arr, Strings, Global } from '@ephox/katamari';
 import { SelectorFilter, Attr, Element, Remove } from '@ephox/sugar';
 
 import { EditorModule, EditorComponent, TINYMCE_SCRIPT_SRC } from '../../../main/ts/public_api';
@@ -43,8 +43,8 @@ UnitTest.asynctest('LoadTinyTest', (success, failure) => {
   const cDeleteTinymce = Chain.op(() => {
     ScriptLoader.reinitialize();
 
-    delete (window as any).tinymce;
-    delete (window as any).tinyMCE;
+    delete Global.tinymce;
+    delete Global.tinyMCE;
 
     const hasTinymceUri = (attrName: string) => (elm: Element) => {
       return Attr.getOpt(elm, attrName).exists((src) => Strings.contains(src, 'tinymce'));
@@ -63,7 +63,7 @@ UnitTest.asynctest('LoadTinyTest', (success, failure) => {
   });
 
   const cAssertTinymceVersion = (version: '4' | '5') => Chain.op(() => {
-    Assertions.assertEq(`Loaded version of TinyMCE should be ${version}`, version, (window as any).tinymce.majorVersion);
+    Assertions.assertEq(`Loaded version of TinyMCE should be ${version}`, version, Global.tinymce.majorVersion);
   });
 
   Pipeline.async({}, [
@@ -87,7 +87,7 @@ UnitTest.asynctest('LoadTinyTest', (success, failure) => {
         Assertions.assertEq(
           'TinyMCE should have been loaded from Cloud',
           'https://cdn.tiny.cloud/1/a-fake-api-key/tinymce/5-dev',
-          (window as any).tinymce.baseURI.source
+          Global.tinymce.baseURI.source
         );
       }),
       cTeardown,

--- a/tinymce-angular-component/src/test/ts/browser/LoadTinyTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/LoadTinyTest.ts
@@ -1,0 +1,98 @@
+import '../alien/InitTestEnvironment';
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { Chain, Log, Pipeline, Assertions } from '@ephox/agar';
+import { UnitTest } from '@ephox/bedrock-client';
+import { Arr, Strings } from '@ephox/katamari';
+import { SelectorFilter, Attr, Element, Remove } from '@ephox/sugar';
+
+import { EditorComponent, TINYMCE_SCRIPT_SRC } from '../../../main/ts/editor/editor.component';
+import { EditorModule } from '../../../main/ts/editor/editor.module';
+import { ScriptLoader } from '../../../main/ts/utils/ScriptLoader';
+
+UnitTest.asynctest('LoadTinyTest', (success, failure) => {
+  const cSetupEditor = (attributes: string[], providers: any[]) => Chain.async<void, void>((_, next) => {
+    @Component({
+      template: `<editor ${attributes.join(' ')}></editor>`
+    })
+    class EditorLoad { }
+
+    TestBed.configureTestingModule({
+      imports: [EditorModule, FormsModule],
+      declarations: [EditorLoad],
+      providers
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(EditorLoad);
+    fixture.detectChanges();
+
+    const editorDebugElement = fixture.debugElement.query(By.directive(EditorComponent));
+    const editorComponent = editorDebugElement.componentInstance;
+
+    editorComponent.onInit.subscribe(() => {
+      editorComponent.editor.on('SkinLoaded', () => {
+        setTimeout(() => {
+          next();
+        }, 0);
+      });
+    });
+  });
+
+  const cDeleteTinymce = Chain.op(() => {
+    ScriptLoader.reinitialize();
+
+    delete (window as any).tinymce;
+    delete (window as any).tinyMCE;
+
+    const hasTinymceUri = (attrName: string) => (elm: Element) => {
+      return Attr.getOpt(elm, attrName).exists((src) => Strings.contains(src, 'tinymce'));
+    };
+
+    const elements = Arr.flatten([
+      Arr.filter(SelectorFilter.all('script'), hasTinymceUri('src')),
+      Arr.filter(SelectorFilter.all('link'), hasTinymceUri('href')),
+    ]);
+
+    Arr.each(elements, Remove.remove);
+  });
+
+  const cTeardown = Chain.op(() => {
+    TestBed.resetTestingModule();
+  });
+
+  const cAssertTinymceVersion = (version: '4' | '5') => Chain.op(() => {
+    Assertions.assertEq(`Loaded version of TinyMCE should be ${version}`, version, (window as any).tinymce.majorVersion);
+  });
+
+  Pipeline.async({}, [
+    Log.chainsAsStep('Should be able to load local version of TinyMCE specified via depdendency injection', '', [
+      cDeleteTinymce,
+
+      cSetupEditor([], [ { provide: TINYMCE_SCRIPT_SRC, useValue: '/project/node_modules/tinymce-5/tinymce.min.js' } ]),
+      cAssertTinymceVersion('5'),
+      cTeardown,
+      cDeleteTinymce,
+
+      cSetupEditor([], [ { provide: TINYMCE_SCRIPT_SRC, useValue: '/project/node_modules/tinymce-4/tinymce.min.js' } ]),
+      cAssertTinymceVersion('4'),
+      cTeardown,
+      cDeleteTinymce,
+    ]),
+    Log.chainsAsStep('Should be able to load TinyMCE from Cloud', '', [
+      cSetupEditor(['apiKey="a-fake-api-key"', 'cloudChannel="5-dev"'], []),
+      cAssertTinymceVersion('5'),
+      Chain.op(() => {
+        Assertions.assertEq(
+          'TinyMCE should have been loaded from Cloud',
+          'https://cdn.tiny.cloud/1/a-fake-api-key/tinymce/5-dev',
+          (window as any).tinymce.baseURI.source
+        );
+      }),
+      cTeardown,
+      cDeleteTinymce
+    ]),
+  ], success, failure);
+});

--- a/tinymce-angular-component/src/test/ts/browser/LoadTinyTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/LoadTinyTest.ts
@@ -9,8 +9,7 @@ import { UnitTest } from '@ephox/bedrock-client';
 import { Arr, Strings } from '@ephox/katamari';
 import { SelectorFilter, Attr, Element, Remove } from '@ephox/sugar';
 
-import { EditorComponent, TINYMCE_SCRIPT_SRC } from '../../../main/ts/editor/editor.component';
-import { EditorModule } from '../../../main/ts/editor/editor.module';
+import { EditorModule, EditorComponent, TINYMCE_SCRIPT_SRC } from '../../../main/ts/public_api';
 import { ScriptLoader } from '../../../main/ts/utils/ScriptLoader';
 
 UnitTest.asynctest('LoadTinyTest', (success, failure) => {

--- a/tinymce-angular-component/src/test/ts/browser/NgModelTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/NgModelTest.ts
@@ -7,10 +7,9 @@ import { By } from '@angular/platform-browser';
 import { Assertions, Chain, Log, Pipeline, Waiter, GeneralSteps, Keyboard, Keys } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { VersionLoader } from '@tinymce/miniature';
-
-import { EditorComponent } from '../../../main/ts/editor/editor.component';
-import { EditorModule } from '../../../main/ts/editor/editor.module';
 import { Element } from '@ephox/sugar';
+
+import { EditorModule, EditorComponent } from '../../../main/ts/public_api';
 
 UnitTest.asynctest('NgModelTest', (success, failure) => {
   // tslint:disable:max-classes-per-file

--- a/tinymce-angular-component/src/test/ts/browser/NgZoneTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/NgZoneTest.ts
@@ -6,7 +6,7 @@ import { Assertions, Chain, Pipeline, Log } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { VersionLoader } from '@tinymce/miniature';
 
-import { EditorComponent } from '../../../main/ts/editor/editor.component';
+import { EditorComponent } from '../../../main/ts/public_api';
 
 UnitTest.asynctest('NgZoneTest', (success, failure) => {
   const createComponent = <T>(componentType: Type<T>) => {


### PR DESCRIPTION
This will simplify self-hosting as it now will be possible to specify the source of TinyMCE which will be used by all instances of tinymce-angular on a page.
Closes #127 

I've added a test which loads TinyMCE from Cloud as well. Thoughts about this?