### PR TITLE
INT-2158: Use modelEvents to define NgModel event triggering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.6.0 (TBD)
+* Added `modelEvents` property to update NgModel
+
 ## 3.5.2 (2020-05-11)
 * Fixed event binding order.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.6.0 (TBD)
+## 3.6.0 (2020-05-22)
 * Added `modelEvents` property to update NgModel
 
 ## 3.5.2 (2020-05-11)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/tinymce-angular",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "description": "Official TinyMCE Angular Component",
   "author": "Ephox Inc",
   "license": "Apache-2.0",

--- a/stories/Settings.ts
+++ b/stories/Settings.ts
@@ -1,5 +1,6 @@
 
 const apiKey = 'qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc';
+const modelEvents = 'change input undo redo';
 const sampleContent = `
 <h2 style="text-align: center;">
   TinyMCE provides a <span style="text-decoration: underline;">full-featured</span> rich text editing experience, and a featherweight download.
@@ -10,5 +11,6 @@ const sampleContent = `
 
 export {
   apiKey,
+  modelEvents,
   sampleContent
 };

--- a/stories/data-binding/DataBinding.component.html
+++ b/stories/data-binding/DataBinding.component.html
@@ -8,6 +8,7 @@
   (onKeyDown)="log($event)"
   [apiKey]="apiKey"
   [init]="{ height: 300 }"
+  [modelEvents]="modelEvents"
   ></editor>
 
 <textarea [(ngModel)]="content" style="width: 100%;" rows="10"></textarea>

--- a/stories/data-binding/DataBinding.component.ts
+++ b/stories/data-binding/DataBinding.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { apiKey, sampleContent } from '../Settings';
+import { apiKey, modelEvents, sampleContent } from '../Settings';
 
 // tslint:disable:no-console
 @Component({
@@ -9,6 +9,7 @@ export class BindingComponent {
   public isEditingContent = true;
   public content = sampleContent;
   public apiKey = apiKey;
+  public modelEvents = modelEvents;
 
   public editContent() {
     this.isEditingContent = !this.isEditingContent;

--- a/tinymce-angular-component/src/main/ts/editor/editor.component.ts
+++ b/tinymce-angular-component/src/main/ts/editor/editor.component.ts
@@ -50,6 +50,7 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
   @Input() public tagName: string | undefined;
   @Input() public plugins: string | undefined;
   @Input() public toolbar: string | string[] | undefined;
+  @Input() public modelEvents = 'change keyup undo redo';
 
   private _elementRef: ElementRef;
   private _element: Element | undefined;
@@ -169,7 +170,7 @@ constructor(
 
   private initEditor(editor: any) {
     editor.on('blur', () => this.ngZone.run(() => this.onTouchedCallback()));
-    editor.on('change keyup undo redo', () => {
+    editor.on(this.modelEvents, () => {
       this.ngZone.run(() => this.onChangeCallback(editor.getContent({ format: this.outputFormat })));
     });
     if (typeof this.initialValue === 'string') {


### PR DESCRIPTION
This should enable users to select which events trigger the NgModel update. By default we are using `change keyup undo redo`. Ideally, we want to change `keyup` to `input` but in order to avoid breaking users currently leveraging the keyup binding we will change that until the next major release. In the meantime users can set the `input` event via the `modelEvents` property

Fixes #163 