### PR TITLE
execute onChange callback only if one is registered

### DIFF
--- a/tinymce-angular-component/src/main/ts/editor/editor.component.ts
+++ b/tinymce-angular-component/src/main/ts/editor/editor.component.ts
@@ -60,7 +60,7 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
   private _editor: any;
 
   private onTouchedCallback = noop;
-  private onChangeCallback = noop;
+  private onChangeCallback: any;
 
 constructor(
   elementRef: ElementRef,
@@ -173,18 +173,24 @@ constructor(
   private initEditor(editor: any) {
     editor.on('blur', () => this.ngZone.run(() => this.onTouchedCallback()));
     editor.on(this.modelEvents, () => {
-      this.ngZone.run(() => this.onChangeCallback(editor.getContent({ format: this.outputFormat })));
+      this.emitOnChange(editor);
     });
     if (typeof this.initialValue === 'string') {
       this.ngZone.run(() => {
         editor.setContent(this.initialValue);
         if (editor.getContent() !== this.initialValue) {
-          this.onChangeCallback(editor.getContent({ format: this.outputFormat }));
+          this.emitOnChange(editor);
         }
         if (this.onInitNgModel !== undefined) {
           this.onInitNgModel.emit(editor);
         }
       });
+    }
+  }
+
+  private emitOnChange(editor: any) {
+    if (this.onChangeCallback) {
+      this.onChangeCallback(editor.getContent({ format: this.outputFormat }));
     }
   }
 }

--- a/tinymce-angular-component/src/main/ts/editor/editor.component.ts
+++ b/tinymce-angular-component/src/main/ts/editor/editor.component.ts
@@ -172,9 +172,7 @@ constructor(
 
   private initEditor(editor: any) {
     editor.on('blur', () => this.ngZone.run(() => this.onTouchedCallback()));
-    editor.on(this.modelEvents, () => {
-      this.emitOnChange(editor);
-    });
+    editor.on(this.modelEvents, () => this.ngZone.run(() => this.emitOnChange(editor)));
     if (typeof this.initialValue === 'string') {
       this.ngZone.run(() => {
         editor.setContent(this.initialValue);


### PR DESCRIPTION
This change is reducing the execution of the onChange callback only, if a callback is registered. This also avoids the cleaning mechanism of the editor [getContent](https://www.tiny.cloud/docs/api/tinymce/tinymce.editor/#getcontent) method.

It reduces the effect of #138 only to cases where a custom onChange callback is registered.