### PR TITLE
fix: set disabled state properly

### DIFF
--- a/tinymce-angular-component/src/main/ts/editor/editor.component.ts
+++ b/tinymce-angular-component/src/main/ts/editor/editor.component.ts
@@ -95,12 +95,8 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
     this.onTouchedCallback = fn;
   }
 
-  public setDisabledState(isDisabled: boolean) {
-    if (this._editor) {
-      this._editor.setMode(isDisabled ? 'readonly' : 'design');
-    } else if (isDisabled) {
-      this.init = { ...this.init, readonly: true };
-    }
+  public setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
   }
 
   public ngAfterViewInit() {


### PR DESCRIPTION
Currently, it's not possible to provide the initial disabled value from the form control options, e.g.:
```ts
<editor [formControl]="control" [init]="{ ... }"></editor>

control = new FormControl({ value: '', disabled: true });
```

We already have the `disabled` property which will:
* call `setMode` if editor is already created
* set `disabled` property, thus it will be retrieved later within the `finalInit` object