### PR TITLE
DEVOPS-35: Add github.com host keys for publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,10 +4,18 @@
 standardProperties()
 
 def addGitHubToKnownHosts() {
+  // GitHub meta information:
+  // https://docs.github.com/en/rest/meta#get-github-meta-information
+  // https://github.blog/changelog/2022-01-18-githubs-ssh-host-keys-are-now-published-in-the-api/
+  String ghMetaJson = sh returnStdout: true,
+    script: "curl -s https://api.github.com/meta"
+  def ghMeta = readJSON text: ghMetaJson
   // Ensure user SSH config directory exists
   sh 'mkdir ~/.ssh && chmod go-rwx ~/.ssh'
-  // Populate keys
-  sh 'ssh-keyscan github.com >> ~/.ssh/known_hosts'
+  // Populate keys GitHub SSH host keys
+  for (hostKey in ghMeta.ssh_keys) {
+    sh "echo '$hostKey' >> ~/.ssh/known_hosts"
+  }
 }
 
 def withPublishCredentials(String dirPath, cl) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,6 +66,13 @@ timestamps {
         }
       }
       container('node') {
+        stage("environment") {
+          // Add github.com to known_hosts for publishing
+          addGitHubToKnownHosts()
+          // Check committer name / email are set
+          sh "git var GIT_COMMITTER_IDENT"
+        }
+
         stage("dependencies") {
           sh 'yarn config set registry https://registry.npmjs.org/'
           yarnInstall()
@@ -89,8 +96,6 @@ timestamps {
           def status = beehiveFlowStatus();
           if (status.branchState == 'releaseReady' && status.isLatest) {
             sshagent (credentials: ['ccde5b3d-cf13-4d70-88cf-ae1e6dfd4ef4']) {
-              // Add github.com to known_hosts for publishing
-              addGitHubToKnownHosts()
               // Build and publish storybook
               sh 'yarn storybook-to-ghpages'
             }


### PR DESCRIPTION
Installs host keys for github.com and ensures the Git committer name is set, so publish can go smoothly.

Actually setting the Git committer details is left to the CI system.