### PR TITLE
fix: ensure form control value updates on paste by adding 'paste' to default modelEvents

### DIFF
--- a/tinymce-angular-component/src/main/ts/editor/editor.component.ts
+++ b/tinymce-angular-component/src/main/ts/editor/editor.component.ts
@@ -40,7 +40,7 @@ export class EditorComponent extends Events implements AfterViewInit, ControlVal
   @Input() public tagName: string | undefined;
   @Input() public plugins: string | undefined;
   @Input() public toolbar: string | string[] | undefined;
-  @Input() public modelEvents = 'change input undo redo';
+  @Input() public modelEvents = 'change input undo redo paste';
   @Input() public allowedEvents: string | string[] | undefined;
   @Input() public ignoreEvents: string | string[] | undefined;
   @Input()


### PR DESCRIPTION
Since the paste plugin is now built-in to TinyMCE core, I believe this should be a default value in modelEvents. Otherwise it causes a lot of confusion as to why the angular form validation fails and prevents submission when pasting content into the editor.