### PR TITLE
hotfix: Fix CI git credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ mixedBeehiveFlow(
     stage("storybook") {
       def status = beehiveFlowStatus()
       if (status.branchState == 'releaseReady' && status.isLatest) {
-        sshagent (credentials: ['3e856116-029e-4c8d-b57d-593b2fba3cb2']) {
+        tinyGit.withGitHubSSHCredentials {
           exec('yarn deploy-storybook')
         }
       } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ mixedBeehiveFlow(
     resourceLimitMemory: '4Gi'
   ],
   customSteps: {
-    stage("storybook") {
+    stage("update storybook") {
       def status = beehiveFlowStatus()
       if (status.branchState == 'releaseReady' && status.isLatest) {
         tinyGit.withGitHubSSHCredentials {


### PR DESCRIPTION
Storybook deployment now uses `tinyGit.withGitHubSSHCredentials`. And I also changed the stage name to match what's in `tinymce-react`.