### PR TITLE
INT-3306: Specify RxJS ^v7.4.0 as a peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Added rxjs ^7.4.0 as a peer dependency. Since last major release now uses rxjs v7 imports. #INT-3306 
+
 ## 8.0.0 - 2024-04-29
 
 ### Added

--- a/tinymce-angular-component/package.json
+++ b/tinymce-angular-component/package.json
@@ -9,7 +9,8 @@
   "peerDependencies": {
     "@angular/core": ">=16.0.0",
     "@angular/common": ">=16.0.0",
-    "@angular/forms": ">=16.0.0"
+    "@angular/forms": ">=16.0.0",
+    "rxjs": "^7.4.0"
   },
   "dependencies": {
     "tinymce": "^7.0.0 || ^6.0.0 || ^5.5.0"


### PR DESCRIPTION
[INT-3306](https://ephocks.atlassian.net/browse/INT-3306)

`tinymce-angular` v8 major release changed certain rxjs imports to ones that are only compatible with rxjs v7. So it should be a peer dependency.

Related issue: #388 

[INT-3306]: https://ephocks.atlassian.net/browse/INT-3306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ