### PR TITLE
INT-3396: adjust tests to support both zoneless/zone.js change detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,23 +20,8 @@ This package is a thin wrapper around [TinyMCE](https://github.com/tinymce/tinym
 |<= 8           |3.x                      |
 |< 5            | Not supported           |
 
-### Not yet Zoneless ( >=Angular v21 )
-* This wrapper still requires `zone.js` to ensure backward compatibility to older Angular versions. Therefore, if your application uses Angular v21 or higher, it needs to include `provideZoneDetection()` in its providers.
-
-```jsx
-import { NgModule, provideZoneChangeDetection } from '@angular/core';
-
-@NgModule({
-  declarations: [
-    // ...
-  ],
-  imports: [
-   // ...
-  ],
-  providers: [ provideZoneChangeDetection() ],
-  bootstrap: [ AppComponent ]
-})
-```
+### Zoneless Support
+This wrapper supports Angular's zoneless change detection. No additional configuration is needed — the component works with both zone-based and zoneless applications.
 
 ### Issues
 

--- a/tinymce-angular-component/src/test/ts/alien/InitTestEnvironment.ts
+++ b/tinymce-angular-component/src/test/ts/alien/InitTestEnvironment.ts
@@ -4,16 +4,11 @@ import 'zone.js/plugins/fake-async-test';
 
 import { TestBed } from '@angular/core/testing';
 import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
-import { NgModule, provideZoneChangeDetection } from '@angular/core';
-
-@NgModule({
-  providers: [ provideZoneChangeDetection() ],
-})
-class AppTestingModule {}
 
 TestBed.initTestEnvironment(
-  [ BrowserTestingModule, AppTestingModule ], platformBrowserTesting(),
+  [ BrowserTestingModule ],
+  platformBrowserTesting(),
   {
-    teardown: { destroyAfterEach: true },
+    teardown: { destroyAfterEach: true }
   }
 );

--- a/tinymce-angular-component/src/test/ts/alien/InitTestEnvironment.ts
+++ b/tinymce-angular-component/src/test/ts/alien/InitTestEnvironment.ts
@@ -15,9 +15,25 @@ import 'zone.js/plugins/fake-async-test';
 
 import { TestBed } from '@angular/core/testing';
 import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
+import { NgModule, provideZonelessChangeDetection } from '@angular/core';
+
+// According to Angular docs, TestBed uses zone-based change detection by default
+// when zone.js is loaded via polyfills:
+// https://angular.dev/guide/zoneless#testing-and-debugging
+//
+// In practice, this behaviour seems to be driven by Angular's built-in test runners
+// (Karma, Vitest) rather than TestBed itself. Since we use Bedrock, we appear to be
+// immune to this — zone-based detection does not kick in automatically even with
+// zone.js loaded. Nonetheless, we explicitly opt into zoneless change detection here
+// to stay aligned with the Angular documentation and to be safe. Zone.js-specific
+// tests can override this with `provideZoneChangeDetection` on a per-test basis.
+@NgModule({
+  providers: [ provideZonelessChangeDetection() ],
+})
+class AppTestingModule {}
 
 TestBed.initTestEnvironment(
-  [ BrowserTestingModule ],
+  [ BrowserTestingModule, AppTestingModule ],
   platformBrowserTesting(),
   {
     teardown: { destroyAfterEach: true }

--- a/tinymce-angular-component/src/test/ts/alien/InitTestEnvironment.ts
+++ b/tinymce-angular-component/src/test/ts/alien/InitTestEnvironment.ts
@@ -1,4 +1,15 @@
 import 'core-js/features/reflect';
+
+// zone.js is imported here because our test suite needs to cover both zoneless and
+// zone.js-based Angular applications. As a component library, our users may run
+// either mode, so we must ensure compatibility with both. Since Angular 21, zoneless
+// is the default, but zone.js remains supported. Once Angular drops zone.js support
+// entirely, this import, ng-zone specific tests and the zone.js devDependency can be removed.
+//
+// Note: importing zone.js patches native browser APIs (addEventListener, setTimeout,
+// setInterval, etc.), but Angular does not use these patches for change detection by
+// default. Change detection only relies on zone.js in tests that explicitly configure
+// `provideZoneChangeDetection`.
 import 'zone.js';
 import 'zone.js/plugins/fake-async-test';
 

--- a/tinymce-angular-component/src/test/ts/browser/EventBlacklistingTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/EventBlacklistingTest.ts
@@ -1,43 +1,62 @@
 import '../alien/InitTestEnvironment';
 
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 
 import { EditorComponent } from '../../../main/ts/public_api';
-import { eachVersionContext, editorHook } from '../alien/TestHooks';
-import { map, merge, timer, first, buffer, Observable, tap, firstValueFrom } from 'rxjs';
-import { NgZone } from '@angular/core';
+import { eachVersionContext, EditorFixture, editorHook } from '../alien/TestHooks';
+import { map, merge, timer, first, buffer, Observable, tap, firstValueFrom, identity } from 'rxjs';
+import { NgZone, provideZoneChangeDetection } from '@angular/core';
 import { Assertions } from '@ephox/agar';
 import { Fun } from '@ephox/katamari';
 import { throwTimeout } from '../alien/TestHelpers';
 
-describe.skip('EventBlacklistingTest', () => {
+describe('EventBlacklistingTest', () => {
   const shouldRunInAngularZone = <T>(source: Observable<T>) =>
     source.pipe(
       tap(() => Assertions.assertEq('Subscribers to events should run within NgZone', true, NgZone.isInAngularZone()))
     );
 
+  const testEventsShouldBeBoundWhenAllowed = async (fixture: EditorFixture<EditorComponent>, isZoneless: boolean) => {
+    const pEventsCompleted = firstValueFrom(
+      merge(
+        fixture.editorComponent.onKeyUp.pipe(map(Fun.constant('onKeyUp')), isZoneless ? identity : shouldRunInAngularZone),
+        fixture.editorComponent.onKeyDown.pipe(map(Fun.constant('onKeyDown')), isZoneless ? identity : shouldRunInAngularZone),
+        fixture.editorComponent.onClick.pipe(map(Fun.constant('onClick')), isZoneless ? identity : shouldRunInAngularZone)
+      ).pipe(throwTimeout(10000, 'Timed out waiting for some event to fire'), buffer(timer(100)), first())
+    );
+    fixture.editor.fire('keydown');
+    fixture.editor.fire('keyclick');
+    fixture.editor.fire('keyup');
+    const eventsCompleted = await pEventsCompleted;
+    Assertions.assertEq('Only one event should have fired', 1, eventsCompleted.length);
+    Assertions.assertEq('Only keyup should fire', 'onKeyUp', eventsCompleted[0]);
+  };
+
   eachVersionContext([ '4', '5', '6', '7', '8' ], () => {
-    const createFixture = editorHook(EditorComponent);
+    context('zoneless', () => {
+      const createFixture = editorHook(EditorComponent);
+      const isZoneless = true;
 
-    it('Events should be bound when allowed', async () => {
-      const fixture = await createFixture({
-        allowedEvents: 'onKeyUp,onClick,onInit',
-        ignoreEvents: 'onClick',
+      it('Events should be bound when allowed', async () => {
+        const fixture = await createFixture({
+          allowedEvents: 'onKeyUp,onClick,onInit',
+          ignoreEvents: 'onClick',
+        });
+        await testEventsShouldBeBoundWhenAllowed(fixture, isZoneless);
       });
+    });
 
-      const pEventsCompleted = firstValueFrom(
-        merge(
-          fixture.editorComponent.onKeyUp.pipe(map(Fun.constant('onKeyUp')), shouldRunInAngularZone),
-          fixture.editorComponent.onKeyDown.pipe(map(Fun.constant('onKeyDown')), shouldRunInAngularZone),
-          fixture.editorComponent.onClick.pipe(map(Fun.constant('onClick')), shouldRunInAngularZone)
-        ).pipe(throwTimeout(10000, 'Timed out waiting for some event to fire'), buffer(timer(100)), first())
-      );
-      fixture.editor.fire('keydown');
-      fixture.editor.fire('keyclick');
-      fixture.editor.fire('keyup');
-      const eventsCompleted = await pEventsCompleted;
-      Assertions.assertEq('Only one event should have fired', 1, eventsCompleted.length);
-      Assertions.assertEq('Only keyup should fire', 'onKeyUp', eventsCompleted[0]);
+    context('with zone.js', () => {
+      const createFixture = editorHook(EditorComponent, { providers: [ provideZoneChangeDetection() ] });
+      const isZoneless = false;
+
+      it('Events should be bound when allowed', async () => {
+        const fixture = await createFixture({
+          allowedEvents: 'onKeyUp,onClick,onInit',
+          ignoreEvents: 'onClick',
+        });
+        await testEventsShouldBeBoundWhenAllowed(fixture, isZoneless);
+      });
     });
   });
 });

--- a/tinymce-angular-component/src/test/ts/browser/EventBlacklistingTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/EventBlacklistingTest.ts
@@ -10,7 +10,7 @@ import { Assertions } from '@ephox/agar';
 import { Fun } from '@ephox/katamari';
 import { throwTimeout } from '../alien/TestHelpers';
 
-describe('EventBlacklistingTest', () => {
+describe.skip('EventBlacklistingTest', () => {
   const shouldRunInAngularZone = <T>(source: Observable<T>) =>
     source.pipe(
       tap(() => Assertions.assertEq('Subscribers to events should run within NgZone', true, NgZone.isInAngularZone()))

--- a/tinymce-angular-component/src/test/ts/browser/NgZoneTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/NgZoneTest.ts
@@ -9,7 +9,7 @@ import { eachVersionContext, fixtureHook } from '../alien/TestHooks';
 import { first } from 'rxjs';
 import { throwTimeout } from '../alien/TestHelpers';
 
-describe('NgZoneTest', () => {
+describe.skip('NgZoneTest', () => {
   eachVersionContext([ '4', '5', '6', '7', '8' ], () => {
     const createFixture = fixtureHook(EditorComponent, { imports: [ EditorComponent ] });
 

--- a/tinymce-angular-component/src/test/ts/browser/NgZoneTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/NgZoneTest.ts
@@ -22,7 +22,7 @@ describe('NgZoneTest', () => {
     it('Subscribers to events should run within NgZone', async () => {
       const fixture = TestBed.createComponent(EditorComponent);
       const editor = fixture.componentInstance;
-      fixture.detectChanges();
+      fixture.detectChanges(); // TODO: consider using fixture.whenStable()
 
       await new Promise<void>((resolve) => {
         editor.onInit.pipe(first(), throwTimeout(10000, 'Timed out waiting for init event')).subscribe(() => {
@@ -36,7 +36,7 @@ describe('NgZoneTest', () => {
     it('Subscribers to onKeyUp should run within NgZone', async () => {
       const fixture = TestBed.createComponent(EditorComponent);
       const editor = fixture.componentInstance;
-      fixture.detectChanges();
+      fixture.detectChanges(); // TODO: consider using fixture.whenStable()
 
       await new Promise<void>((resolve) => {
         editor.onKeyUp.pipe(first(), throwTimeout(10000, 'Timed out waiting for key up event')).subscribe(() => {

--- a/tinymce-angular-component/src/test/ts/browser/NgZoneTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/NgZoneTest.ts
@@ -1,22 +1,29 @@
 import '../alien/InitTestEnvironment';
 
-import { NgZone } from '@angular/core';
+import { NgZone, provideZoneChangeDetection } from '@angular/core';
 import { Assertions } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
 
 import { EditorComponent } from '../../../main/ts/editor/editor.component';
-import { eachVersionContext, fixtureHook } from '../alien/TestHooks';
+import { eachVersionContext } from '../alien/TestHooks';
 import { first } from 'rxjs';
 import { throwTimeout } from '../alien/TestHelpers';
+import { TestBed } from '@angular/core/testing';
 
-describe.skip('NgZoneTest', () => {
+describe('NgZoneTest', () => {
   eachVersionContext([ '4', '5', '6', '7', '8' ], () => {
-    const createFixture = fixtureHook(EditorComponent, { imports: [ EditorComponent ] });
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [ EditorComponent ],
+        providers: [ provideZoneChangeDetection() ]
+      }).compileComponents();
+    });
 
     it('Subscribers to events should run within NgZone', async () => {
-      const fixture = createFixture();
+      const fixture = TestBed.createComponent(EditorComponent);
       const editor = fixture.componentInstance;
       fixture.detectChanges();
+
       await new Promise<void>((resolve) => {
         editor.onInit.pipe(first(), throwTimeout(10000, 'Timed out waiting for init event')).subscribe(() => {
           Assertions.assertEq('Subscribers to onInit should run within NgZone', true, NgZone.isInAngularZone());
@@ -27,9 +34,10 @@ describe.skip('NgZoneTest', () => {
 
     // Lets just test one EventEmitter, if one works all should work
     it('Subscribers to onKeyUp should run within NgZone', async () => {
-      const fixture = createFixture();
+      const fixture = TestBed.createComponent(EditorComponent);
       const editor = fixture.componentInstance;
       fixture.detectChanges();
+
       await new Promise<void>((resolve) => {
         editor.onKeyUp.pipe(first(), throwTimeout(10000, 'Timed out waiting for key up event')).subscribe(() => {
           Assertions.assertEq('Subscribers to onKeyUp should run within NgZone', true, NgZone.isInAngularZone());

--- a/tinymce-angular-component/src/test/ts/browser/NgZoneTest.ts
+++ b/tinymce-angular-component/src/test/ts/browser/NgZoneTest.ts
@@ -2,28 +2,21 @@ import '../alien/InitTestEnvironment';
 
 import { NgZone, provideZoneChangeDetection } from '@angular/core';
 import { Assertions } from '@ephox/agar';
-import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 
 import { EditorComponent } from '../../../main/ts/editor/editor.component';
-import { eachVersionContext } from '../alien/TestHooks';
+import { eachVersionContext, fixtureHook } from '../alien/TestHooks';
 import { first } from 'rxjs';
 import { throwTimeout } from '../alien/TestHelpers';
-import { TestBed } from '@angular/core/testing';
 
 describe('NgZoneTest', () => {
   eachVersionContext([ '4', '5', '6', '7', '8' ], () => {
-    beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [ EditorComponent ],
-        providers: [ provideZoneChangeDetection() ]
-      }).compileComponents();
-    });
+    const createFixture = fixtureHook(EditorComponent, { imports: [ EditorComponent ], providers: [ provideZoneChangeDetection() ] });
 
     it('Subscribers to events should run within NgZone', async () => {
-      const fixture = TestBed.createComponent(EditorComponent);
+      const fixture = createFixture();
       const editor = fixture.componentInstance;
-      fixture.detectChanges(); // TODO: consider using fixture.whenStable()
-
+      fixture.detectChanges();
       await new Promise<void>((resolve) => {
         editor.onInit.pipe(first(), throwTimeout(10000, 'Timed out waiting for init event')).subscribe(() => {
           Assertions.assertEq('Subscribers to onInit should run within NgZone', true, NgZone.isInAngularZone());
@@ -34,10 +27,9 @@ describe('NgZoneTest', () => {
 
     // Lets just test one EventEmitter, if one works all should work
     it('Subscribers to onKeyUp should run within NgZone', async () => {
-      const fixture = TestBed.createComponent(EditorComponent);
+      const fixture = createFixture();
       const editor = fixture.componentInstance;
-      fixture.detectChanges(); // TODO: consider using fixture.whenStable()
-
+      fixture.detectChanges();
       await new Promise<void>((resolve) => {
         editor.onKeyUp.pipe(first(), throwTimeout(10000, 'Timed out waiting for key up event')).subscribe(() => {
           Assertions.assertEq('Subscribers to onKeyUp should run within NgZone', true, NgZone.isInAngularZone());


### PR DESCRIPTION
## Summary

No production code was changed in this PR. The only changes are to the test infrastructure and the README.

The test suite now runs against a **zoneless** Angular environment by default, matching the direction Angular is heading (zoneless by default since Angular 21). Tests that specifically verify zone.js-based behavior explicitly opt into `provideZoneChangeDetection()` on a per-test basis.

This ensures that the TinyMCE Angular component works correctly in both zoneless and zone.js-based applications.

## What changed

- **Default test environment switched to zoneless** — `InitTestEnvironment.ts` now uses `provideZonelessChangeDetection()` instead of `provideZoneChangeDetection()`.
- **Zone.js-specific tests explicitly opt in** — `NgZoneTest` and the zone.js context in `EventBlacklistingTest` provide `provideZoneChangeDetection()` at the test level.
- **Event blacklisting test covers both modes** — the test now runs in both a zoneless and a zone.js context, verifying event binding works correctly in each.
- **README updated** — replaced the "Not yet Zoneless" section with a "Zoneless Support" statement confirming the component works in both modes.

## FAQ

### Can I use this integration in a zoneless Angular application?

Yes. The TinyMCE Angular component works in zoneless applications without any additional configuration. No production code changes were needed to support zoneless — the component was already compatible.

### Can I use this integration in a zone.js Angular application?

Yes. The component continues to work with zone.js-based change detection, just as it always has. The component injects `NgZone` and uses it to guard against zone pollution — ensuring that TinyMCE's internal activity doesn't trigger unnecessary change detection cycles. This has always been the case and is not new to this PR. 


https://angular.dev/best-practices/zone-pollution

### Are you sure we are zoneless? I can see `NgZone` injected in the editor component.

Yes. Injecting `NgZone` does not make the component zone-dependent. In a zoneless application, Angular provides a no-op `NgZone` instance — calls to `NgZone.run` and `NgZone.runOutsideAngular` simply execute the callback directly without any zone-related side effects. We keep these calls because they are still needed for applications that use zone.js, and as the Angular docs state that removing them could cause performance regressions for those users.

> **NgZone.run and NgZone.runOutsideAngular are compatible with Zoneless**
>
> NgZone.run and NgZone.runOutsideAngular do not need to be removed in order for code to be compatible with Zoneless applications. In fact, removing these calls can lead to performance regressions for libraries that are used in applications that still rely on ZoneJS.


https://angular.dev/guide/zoneless#requirements-for-zoneless-compatibility

### Are you sure you're zoneless? I can see `zone.js` in our `package.json` and imported in the tests.

The `zone.js` dependency and import exist solely for testing purposes. Our test suite needs to verify that the component works correctly in both zoneless and zone.js-based applications. To test the zone.js path, we need zone.js loaded so that tests can opt into `provideZoneChangeDetection()`. Importing zone.js patches native browser APIs, but Angular does not use those patches for change detection unless explicitly configured to do so. The default test environment uses `provideZonelessChangeDetection()`, so the majority of tests run in a truly zoneless context. Once Angular drops zone.js support entirely, the import, the zone-specific tests, and the `zone.js` devDependency can all be removed.

### If no production code changed, why did tests fail when you enabled zoneless change detection?

The tests themselves made assumptions that are only valid in a zone.js environment. Specifically, the event blacklisting test asserted that event callbacks run inside `NgZone` (`NgZone.isInAngularZone() === true`). In a zoneless application there is no Angular zone, so this assertion doesn't apply. The fix was to split the test into two contexts — one zoneless and one zone.js-based — and only assert zone membership in the zone.js context. Similarly, `NgZoneTest` explicitly verifies that events run inside Angular's zone — this is inherently a zone.js-specific concern, so it now opts into `provideZoneChangeDetection()` at the test level.

### Is importing `zone.js` in tests a good idea? Won't it affect zoneless tests?

Yes, importing zone.js patches native browser APIs (`addEventListener`, `setTimeout`, etc.), so zoneless tests will run against patched APIs rather than native ones. In practice, this shouldn't matter — zone.js is a well-tested library, the patched APIs behave the same as the native ones, and it may affect performance slightly at most. The only way to avoid this would be to run two separate test runner instances — one with zone.js loaded and one without — which isn't worth the complexity.

### Shouldn't we run all tests twice — once zoneless and once with zone.js?

I reviewed all the tests and where I judged it matters — such as event blacklisting — I run them in both modes. For the rest, I don't think running with or without zone.js makes a difference given the kind of tests we have, so I run them once in the default zoneless environment. This is a judgment call, and if we find cases where it does matter, we can always add a zone.js context to those tests later.

