### PR TITLE
INT-3427: make fixtureHook use beforeEach instead of before

### DIFF
--- a/tinymce-angular-component/src/test/ts/alien/TestHooks.ts
+++ b/tinymce-angular-component/src/test/ts/alien/TestHooks.ts
@@ -12,7 +12,7 @@ import type { Editor } from 'tinymce';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
 export const fixtureHook = <T = unknown>(component: Type<T>, moduleDef: TestModuleMetadata) => {
-  before(async () => {
+  beforeEach(async () => {
     await TestBed.configureTestingModule(moduleDef).compileComponents();
   });
 


### PR DESCRIPTION
Problem: `fixtureHook` calls `TestBed.configureTestingModule` inside a `before` hook, which runs once per suite. However, `InitTestEnvironment.ts` initializes `TestBed` with `destroyAfterEach: true`, which resets the module after every test.

This means the first test in any suite works fine, but every subsequent test fails because:

1. The first test completes and `destroyAfterEach` tears down the configured module
2. The second test calls `TestBed.createComponent()`, but the module is no longer configured providers, imports, and compiled components are gone 
3. `before` doesn't re-run, so nothing reconfigures the module

**Impact:** Only the first test in suite can run successfully. The rest fail regardless of their content. ( Assuming that succesfull module definition is required for the test to run )

**Fix:** Change `before` to `beforeEach` in `fixtureHook` so that `configureTestingModule` runs before every test, matching the teardown lifecycle.

**Example**. In this example only the first test will succeed, and the second one will always fail, regardless of content of these tests. If we swap the order, only the first one will succeed. It happens because providers array is always cleaned `afterEach` test. 

```
@Injectable()
class CounterService {
  public value = 0;
  public increment(): void {
    this.value++;
  }
}

@Component({
  imports: [ EditorComponent ],
  template: `<editor /> {{ counterService.value }}`,
})
class CounterComponent {
  public counterService = inject(CounterService);
}

describe('ExampleTest', () => {
  eachVersionContext([ '8' ], () => {
    const createFixture = editorHook(CounterComponent, { providers: [ CounterService ] });

    it('should initialize counter at zero', async () => {
      const fixture = await createFixture();
      const { counterService } = fixture.componentInstance;
      Assertions.assertEq('Counter should start at 0', 0, counterService.value);
    });

    it('should increment and decrement the counter', async () => {
      const fixture = await createFixture();
      const { counterService } = fixture.componentInstance;

      counterService.increment();
      counterService.increment();
      Assertions.assertEq('Counter should be 2 after two increments', 2, counterService.value);
    });
  });
});

```